### PR TITLE
Fix squeezed images on mobile by controlling icon size with width instead of height

### DIFF
--- a/src/pages/generator.js
+++ b/src/pages/generator.js
@@ -76,7 +76,7 @@ class Generator extends Component {
 
     //1. Generate Tech blocks
     selectedTech = selectedTech.map((tech) => {
-      const techBlock = `<img height="${iconSize}" src="${tech.link}" alt="${tech.name}" title="${tech.name}"/>`;
+      const techBlock = `<img width="${iconSize}" src="${tech.link}" alt="${tech.name}" title="${tech.name}"/>`;
       if (includeCode) return `<code>${techBlock}</code>`;
       return techBlock;
     });


### PR DESCRIPTION
Hey, great project!

Added a few icons to my profile and noticed after some time that they are "squeezed" on mobile or narrower windows, as a result of contorlling the size of the icons by `height` + whatever formatting GitHub throws on top.

Switching to `width` resolves this, and now the icons resize without affecting their aspect ratio.

You can see the squeeze in effect in this [earlier version of my profile](https://github.com/Antvirf/Antvirf/tree/f87d1e40e045943496013a89473700134ef23a8c) if you open it in a really narrow browser, pic below also:

![image](https://github.com/marwin1991/profile-technology-icons/assets/26534322/a9a2c06d-9004-4692-8c05-a8fc71c709a2)


After a fix, [new version](https://github.com/Antvirf/Antvirf/tree/b6c6848093dcc4ec097108c244b33feef062287a), pic below:

![image](https://github.com/marwin1991/profile-technology-icons/assets/26534322/6f45e988-6791-433a-8774-999cbe9a564b)
