### PR TITLE
Update Python technology icons in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,16 +262,10 @@ endorsement._
 
 
 ### 🐍 Python
-
 |                                                          Technology Icon                                                          | Technology Name | URL                                                                                                         |
 | :-------------------------------------------------------------------------------------------------------------------------------: | :-------------: | ----------------------------------------------------------------------------------------------------------- |
-
-
-|<img height="50" src="https://raw.githubusercontent.com/Anand905536/profile-technology-icons/refs/heads/main/icons/pydantic.png">  |   pydantic   |
-
+| <img height="50" src="https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/pydantic.png">  |    pydantic     | `https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/pydantic.png`  |
 |  <img height="50" src="https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/python.png">   |     Python      | `https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/python.png`    |
-
-
 |   <img height="50" src="https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/flask.png">   |      Flask      | `https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/flask.png`     |
 |  <img height="50" src="https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/pytest.png">   |     pytest      | `https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/pytest.png`    |
 |  <img height="50" src="https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/django.png">   |     Django      | `https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/django.png`    |
@@ -281,7 +275,6 @@ endorsement._
 |   <img height="50" src="https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/odoo.png">    |      Odoo       | `https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/odoo.png`      |
 | <img height="50" src="https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/streamlit.png"> |    Streamlit    | `https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/streamlit.png` |
 |  <img height="50" src="https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/fastapi.png">  |     FastAPI     | `https://raw.githubusercontent.com/marwin1991/profile-technology-icons/refs/heads/main/icons/fastapi.png`   |
-
 ### 🐘 php
 
 |                                                             Technology Icon                                                             | Technology Name | URL                                                                                                               |


### PR DESCRIPTION
### Description
This Pull Request fixes the `404 Not Found` error for the Pydantic icon and completely restores the README markdown table layout, fixing the layout regression introduced in a previous PR.

###  Changes Made
1. **Fixed Asset Path**: Changed the Pydantic image `src` URL to point directly to the main repository (`marwin1991`) instead of the broken, outdated fork.
2. **Completed Table Data**: Added the missing URL link to the third column of the Pydantic row.
3. **Restored Table Formatting**: Fixed broken markdown pipes (`|`) and newlines that caused Streamlit, FastAPI, and other icons to fall out of the table grid layout.

### Related Issues
Closes #573
